### PR TITLE
chore: upgraded RNW to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-native": "^0.59.5",
     "react-native-elements": "^1.2.5",
     "react-native-vector-icons": "^6.4.2",
-    "react-native-web": "^0.9.x"
+    "react-native-web": "^0.11.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12564,10 +12564,10 @@ react-native-vector-icons@^6.4.2:
     prop-types "^15.6.2"
     yargs "^13.2.2"
 
-react-native-web@^0.9.x:
-  version "0.9.13"
-  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.9.13.tgz#b277ccce2e4985a256ed340823104c08505f3096"
-  integrity sha512-P1nCvBVFrv3J5BXu39iS4A3fR7m0vtGaCAy4MigAtZpakIuara/98h516fDQajPqoVy2T4cQgYZUQAr+FBnppQ==
+react-native-web@^0.11.0:
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/react-native-web/-/react-native-web-0.11.7.tgz#d173d5a9b58db23b6d442c4bc4c81e9939adac23"
+  integrity sha512-w1KAxX2FYLS2GAi3w3BnEZg/IUu7FdgHnLmFKHplRnHMV3u1OPB2EVA7ndNdfu7ds4Rn2OZjSXoNh6F61g3gkA==
   dependencies:
     array-find-index "^1.0.2"
     create-react-class "^15.6.2"


### PR DESCRIPTION
@haruelrovix This addresses issue #17. I have checked with RNW changelog [here](https://github.com/necolas/react-native-web/releases) for both 0.10 and 0.11, everything seems fine.